### PR TITLE
Disable telemetry

### DIFF
--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -83,6 +83,8 @@ spec:
           env:
             - name: COCKROACH_CHANNEL
               value: kubernetes-secure
+            - name: COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING
+              value: "true"
           ports:
             - containerPort: 26257
               name: grpc


### PR DESCRIPTION
Note this only takes effect for new clusters.. existing clusters will
require a `SET CLUSTER SETTING diagnostics.reporting.enabled = false;`

See https://www.cockroachlabs.com/docs/stable/diagnostics-reporting.html