### PR TITLE
Use percentage for --cache and --max-sql-memory flags

### DIFF
--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
             - "-ecx"
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            - "exec /cockroach/cockroach start --logtostderr=WARNING --certs-dir /cockroach/cockroach-certs --advertise-addr $(hostname -f) --http-addr 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 256MB --max-sql-memory 256MB"
+            - "exec /cockroach/cockroach start --logtostderr=WARNING --certs-dir /cockroach/cockroach-certs --advertise-addr $(hostname -f) --http-addr 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
           env:
             - name: COCKROACH_CHANNEL
               value: kubernetes-secure


### PR DESCRIPTION
This removes the need to override the command when memory is increased