### PR TITLE
Remove hardcoded aws specific storage class

### DIFF
--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -188,7 +188,6 @@ spec:
     - metadata:
         name: datadir
       spec:
-        storageClassName: ebs-gp2
         accessModes:
           - "ReadWriteOnce"
         resources:


### PR DESCRIPTION
For merit move. NB default for aws is not ebs-gp2, so we're going to have to patch all clusters