### PR TITLE
Reduce default pvc storage

### DIFF
--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -193,4 +193,4 @@ spec:
           - "ReadWriteOnce"
         resources:
           requests:
-            storage: 100Gi
+            storage: 10Gi


### PR DESCRIPTION
We have quite a few cases where crdb clusters are grossly oversized,
because the 100Gi is more often than not too much. It's easier to
increase than decrease, and a smaller default removes the chance of
accidentally over-provisioning.

NB the larger default may make sense to get increased iops, but that
no longer applies as we move to merit.