### PR TITLE
Revert "chore: update budget api"

### DIFF
--- a/base/budget.yaml
+++ b/base/budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: cockroachdb-budget


### PR DESCRIPTION
Reverts utilitywarehouse/cockroachdb-manifests#16

prod-aws is not running 1.21 yet