### PR TITLE
Bump cockroachdb to v21.1.1

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 images:
   - name: cockroachdb
     newName: cockroachdb/cockroach
-    newTag: v20.2.10
+    newTag: v21.1.1
   - name: cockroach-cfssl-certs
     newName: quay.io/utilitywarehouse/cockroach-cfssl-certs
     newTag: latest


### PR DESCRIPTION
Major version bump, careful now..