### PR TITLE
feat: add semaphore annotation for x-cluster identification

### DIFF
--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: cockroachdb
+        policy.semaphore.uw.io/name: cockroachdb
     spec:
       serviceAccountName: cockroachdb
       shareProcessNamespace: true


### PR DESCRIPTION
Should enable x-cluster network policies https://github.com/utilitywarehouse/documentation/blob/master/infra/kubernetes/cross-cluster-networkpolicies.md