### PR TITLE
Set job resources request and limits

### DIFF
--- a/base/backup-init-job.yaml
+++ b/base/backup-init-job.yaml
@@ -72,6 +72,13 @@ spec:
         - name: cockroachdb-scripts
           mountPath: /opt/scripts
           readOnly: true
+        resources:
+          requests:
+            cpu: 0
+            memory: 128Mi
+          limits:
+            cpu: 1 
+            memory: 512Mi
       restartPolicy: OnFailure
       volumes:
       - name: client-certs

--- a/base/init-job.yaml
+++ b/base/init-job.yaml
@@ -48,6 +48,13 @@ spec:
         - "/bin/bash"
         - "-c"
         - "/cockroach/cockroach init --certs-dir=/cockroach-certs --host=cockroachdb-0.cockroachdb 2>&1 | grep 'initialized'"
+        resources:
+          requests:
+            cpu: 0
+            memory: 128Mi
+          limits:
+            cpu: 1
+            memory: 512Mi
       restartPolicy: OnFailure
       volumes:
       - name: client-certs


### PR DESCRIPTION
Lack of resource limits means that the namespace defaults are used, which might not be enough and cause the jobs to crash.