### PR TITLE
Remove usage of deprecated tolerate-unready-endpoints annotation

### DIFF
--- a/base/service.yaml
+++ b/base/service.yaml
@@ -31,11 +31,6 @@ metadata:
   labels:
     app: cockroachdb
   annotations:
-    # Use this annotation in addition to the actual publishNotReadyAddresses
-    # field below because the annotation will stop being respected soon but the
-    # field is broken in some versions of Kubernetes:
-    # https://github.com/kubernetes/kubernetes/issues/58662
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"


### PR DESCRIPTION
`publishNotReadyAddresses` is aready being set, and there isn't any clear need to continue to set `service.alpha.kubernetes.io/tolerate-unready-endpoints` now