### PR TITLE
Always run the client

### DIFF
--- a/base/client.yaml
+++ b/base/client.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: &app cockroachdb-client
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: *app


### PR DESCRIPTION
Instead of opting in which is most common, those that don't want the client can patch the base and set the replicas to zero