### PR TITLE
docs: add backstage-support

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cockroachdb-manifests
+  annotations:
+    github.com/project-slug: utilitywarehouse/cockroachdb-manifests
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: documentation
+  lifecycle: experimental
+  owner: customer-support

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: 'Customer Support Account'
+
+nav:
+  - Home: index.md
+  - Scaling: scaling.md
+  - Upgrade: upgrade.md
+  - PVC Resize: pvc-resize.md
+  
+plugins:
+  - techdocs-core
+
+markdown_extensions:
+  - admonition


### PR DESCRIPTION
## Summary

adds backstage support, the owner is set as `customer support` which needs to be changed with the team responsible for this repo, since this is is a collaboration between diff individuals how do we want to proceed? do we have a `dev experience` team? 

see example reference [setup for teams here](https://github.com/utilitywarehouse/customer-support/blob/main/catalog/catalog-info.yaml#L99)