### PR TITLE
dont recreate existing schedules

### DIFF
--- a/base/scripts.yaml
+++ b/base/scripts.yaml
@@ -43,10 +43,8 @@ data:
 
     $SQL_CMD << EOF
       BEGIN;
-      -- clear any existing schedules
-      DROP SCHEDULES SELECT id FROM [SHOW SCHEDULES] WHERE label = 'cluster_backup';
       -- create a new schedule
-      CREATE SCHEDULE cluster_backup
+      CREATE SCHEDULE IF NOT EXISTS cluster_backup
         FOR BACKUP INTO '$BACKUP_DESTINATION_URL'
           RECURRING '$BACKUP_SCHEDULE'
           FULL BACKUP ALWAYS


### PR DESCRIPTION
since the change to give the init jobs a TTL for kube to cleanup, further KA runs re-run the init jobs, and if a backup is in progress, this will drop the running backup and cause an alert

i don't think we need to drop existing schedules on runs of this job, but it does mean changes to location or schedule will need manual intervention - i can't think of a previous example of these values being changed, though