### PR TITLE
Add example serviceAccount

### DIFF
--- a/examples/kustomization.yaml
+++ b/examples/kustomization.yaml
@@ -24,6 +24,7 @@ configMapGenerator:
       - config-template.json=config/certificate-authority-config-config-template.json
 resources:
   - certificate-authority.yaml
+  - sa.yaml
   - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v22.1.7-0
 
 patchesStrategicMerge:

--- a/examples/sa.yaml
+++ b/examples/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb


### PR DESCRIPTION
I'm trying to turn the `example` resources to be 'copy+paste'-able.