### PR TITLE
Fix example ca-config

### DIFF
--- a/examples/config/ca-config
+++ b/examples/config/ca-config
@@ -1,4 +1,4 @@
-ca.node.profile=server
+ca.node.profile=client-server
 ca.client.profile=client
 ca.endpoint=certificate-authority:8080
 ca.serverCert.expiryHours=24


### PR DESCRIPTION
Must match profile name from config https://github.com/utilitywarehouse/cockroachdb-manifests/blob/master/examples/config/certificate-authority-config-config-template.json#L19