### PR TITLE
Add opslevel OSS tag to client

### DIFF
--- a/base/client.yaml
+++ b/base/client.yaml
@@ -6,6 +6,7 @@ metadata:
     "app.uw.systems/description": "Used to connect and query the cockroachdb databases."
     "app.uw.systems/repos.cockroachdb-manifests": "https://github.com/utilitywarehouse/cockroachdb-manifests"
     "app.uw.systems/tier": "tier_4"
+    "app.uw.systems/tags.oss": "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Missed as part of https://github.com/utilitywarehouse/cockroachdb-manifests/pull/92