### PR TITLE
Pin version for cockroach-cfssl-certs

### DIFF
--- a/base/backup-init-job.yaml
+++ b/base/backup-init-job.yaml
@@ -10,7 +10,6 @@ spec:
       initContainers:
       - name: init-certs
         image: cockroach-cfssl-certs
-        imagePullPolicy: Always
         command: ["cockroach-certs"]
         env:
         - name: CERTIFICATE_TYPE

--- a/base/init-job.yaml
+++ b/base/init-job.yaml
@@ -11,7 +11,6 @@ spec:
       initContainers:
       - name: init-certs
         image: cockroach-cfssl-certs
-        imagePullPolicy: Always
         command: ["cockroach-certs"]
         env:
         - name: CERTIFICATE_TYPE

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -7,7 +7,7 @@ images:
     newTag: v23.2.2
   - name: cockroach-cfssl-certs
     newName: quay.io/utilitywarehouse/cockroach-cfssl-certs
-    newTag: latest
+    newTag: v1.0.0
 
 resources:
   - client.yaml

--- a/base/statefulset.yaml
+++ b/base/statefulset.yaml
@@ -41,7 +41,6 @@ spec:
       initContainers:
         - name: init-certs
           image: cockroach-cfssl-certs
-          imagePullPolicy: Always
           command:
             - "sh"
             - "-c"
@@ -148,7 +147,6 @@ spec:
               memory: "1Gi"
         - name: certs-refresh
           image: cockroach-cfssl-certs
-          imagePullPolicy: Always
           command:
             - "sh"
             - "-c"


### PR DESCRIPTION
Pulling latest is dangerous as breaking changes can affect Production
deployments.

Removing `imagePullPolicy: Always` also means we remove immediate
dependency on Quay and can stop hammering them on every restart.
