### PR TITLE
Use our own copy of cockroach db images

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: cockroachdb
-    newName: cockroachdb/cockroach
+    newName: registry.uw.systems/system-public/cockroach
     newTag: v23.2.2
   - name: cockroach-cfssl-certs
     newName: quay.io/utilitywarehouse/cockroach-cfssl-certs


### PR DESCRIPTION
Most of the original images use deprecated v1 schema. Switching to our
registry with updated v2 images
